### PR TITLE
Fix: Pass claimsData prop to Sidebar component

### DIFF
--- a/src/components/home.tsx
+++ b/src/components/home.tsx
@@ -173,7 +173,8 @@ const Home = () => {
     <div className="flex h-screen bg-gray-50">
       <Sidebar 
         activeSection={activeSection} 
-        onSectionChange={setActiveSection} 
+        onSectionChange={setActiveSection}
+        claimsData={claimsData}
       />
       <motion.div
         key={activeSection}


### PR DESCRIPTION
This commit fixes a crash in the Sidebar component by passing the `claimsData` prop from the Home component. The Sidebar was attempting to call `.filter()` on an undefined `claimsData` prop, which caused a runtime error.