### PR TITLE
Fix: Enable vertical scrolling for main content area

### DIFF
--- a/src/components/home.tsx
+++ b/src/components/home.tsx
@@ -181,7 +181,7 @@ const Home = () => {
         initial={{ opacity: 0, x: 20 }}
         animate={{ opacity: 1, x: 0 }}
         transition={{ duration: 0.3 }}
-        className="flex-1 overflow-hidden"
+        className="flex-1 overflow-y-auto"
       >
         {renderContent()}
       </motion.div>


### PR DESCRIPTION
This commit fixes an issue where content in some sections was being cut off by enabling vertical scrolling for the main content area. The `overflow-hidden` class was replaced with `overflow-y-auto` in the main content container.