### PR TITLE
Fix: Ensure claims are correctly categorized

### DIFF
--- a/src/components/home.tsx
+++ b/src/components/home.tsx
@@ -120,7 +120,7 @@ const Home = () => {
       classification: "Appeal",
       actionNeeded: "📝 Appeal with docs",
       eobSnippet: "Claim denied: Missing required documentation",
-      status: "active",
+      status: "pending",
       originalDenial: "Missing required documentation",
     },
     {


### PR DESCRIPTION
This commit fixes an issue where claims were not being correctly categorized into the 'Pending', 'Denied', and 'Paid' tabs. The sample data has been updated to ensure that there are claims with the correct statuses to be properly categorized.